### PR TITLE
Fix mutex freeze when editing

### DIFF
--- a/GW Launcher/Classes/Account.cs
+++ b/GW Launcher/Classes/Account.cs
@@ -22,6 +22,8 @@ public class Account
 
     public string title = "";
 
+    public Guid guid = Guid.NewGuid();
+
     public string Name
     {
         get

--- a/GW Launcher/Forms/AddAccountForm.cs
+++ b/GW Launcher/Forms/AddAccountForm.cs
@@ -12,9 +12,18 @@ public partial class AddAccountForm : Form
         account = new Account();
         InitializeComponent();
     }
-
+    protected override void OnFormClosing(FormClosingEventArgs e)
+    {
+        SaveAccount();
+        base.OnFormClosing(e);
+    }
     private void ButtonDone_Click(object sender, EventArgs e)
     {
+        SaveAccount();
+    }
+    private void SaveAccount()
+    {
+
         account.title = textBoxTitle.Text;
         account.email = textBoxEmail.Text;
         account.password = textBoxPassword.Text;
@@ -22,9 +31,7 @@ public partial class AddAccountForm : Form
         account.gwpath = textBoxPath.Text;
         account.elevated = checkBoxElevated.Checked;
         account.extraargs = textBoxExtraArguments.Text;
-
-        finished = true;
-        Close();
+        MainForm.OnAccountSaved(account);
     }
 
     private void AddAccountForm_Load(object sender, EventArgs e)


### PR DESCRIPTION
(master seemed more up-to-date so sorry if this is on wrong branch)

There were a few bugs around editing an account, saving and then trying to launch, or the other way around; main thread got greedy grabbing the mutex aswell. Allow edit window to be used separately from main window and avoid having to use mutexes for the edit

Guid introduced because anything identifying an account could be edited at this point, and the system needs to know if its an edit to an existing record or a new one