### PR TITLE
chore(ci): allowed build paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,12 @@ name: Build and Release
 on:
     push:
         branches: [ "master" ]
-        paths-ignore:
-            - 'README.md'
-            - '.github/**'
+        paths:
+            - 'GW Launcher/**'
     pull_request:
         branches: [ "master" ]
+        paths:
+            - 'GW Launcher/**'
 defaults:
     run:
         shell: pwsh


### PR DESCRIPTION
Addresses Jon's `How can I avoid this compiling a brand new bloody version of gwlauncher?` from https://github.com/gwdevhub/gwlauncher/commit/45c9f57f24b7a56ad6ab5b7dfd61a4378f5ec44e